### PR TITLE
Change API to reflect other PAF uses

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rpaf
 Type: Package
 Title: Calculate Population Attributable Fractions for Cohort Studies
-Version: 0.3.1
+Version: 0.4.0
 Authors@R: person("Ian", "Powell", email = "i.powell@student.unsw.edu.au",
     role = c("cre", "aut"))
 Description: This package provides methods for calculating PAFs for incidence of 

--- a/R/disease_calc.R
+++ b/R/disease_calc.R
@@ -71,7 +71,7 @@ dpaf_delta_Sp <- function(Sp, ID, PERIOD) {
 #' @keywords internal
 dpaf_I <- function(lambda_l, dSp, PERIOD) {
   as.vector(tapply(
-    lambda_l[["disease"]] / do.call(`+`, lambda_l) * dSp,
+    lambda_l[["primary"]] / do.call(`+`, lambda_l) * dSp,
     PERIOD, mean
   ))
 }
@@ -146,16 +146,16 @@ dpaf_grad_delta_Sp <- function(grad_S_l, Sp, ID, PERIOD) {
 #' @return named vector of mortalities \eqn{I} (see Warning on names)
 #' @keywords internal
 dpaf_grad_I <- function(grad_lambda_l, grad_dSp_l, lambda_l, dSp, PERIOD) {
-  summands_d <- grad_lambda_l[["disease"]] *
-    lambda_l[["mortality"]] / do.call(`+`, lambda_l)^2 * dSp +
-    grad_dSp_l[["disease"]] * lambda_l[["disease"]] / do.call(`+`, lambda_l)
+  summands_d <- grad_lambda_l[["primary"]] *
+    lambda_l[["secondary"]] / do.call(`+`, lambda_l)^2 * dSp +
+    grad_dSp_l[["primary"]] * lambda_l[["primary"]] / do.call(`+`, lambda_l)
 
-  summands_m <- -grad_lambda_l[["mortality"]] *
-    lambda_l[["disease"]] / do.call(`+`, lambda_l)^2 * dSp +
-    grad_dSp_l[["mortality"]] * lambda_l[["disease"]] / do.call(`+`, lambda_l)
+  summands_m <- -grad_lambda_l[["secondary"]] *
+    lambda_l[["primary"]] / do.call(`+`, lambda_l)^2 * dSp +
+    grad_dSp_l[["secondary"]] * lambda_l[["primary"]] / do.call(`+`, lambda_l)
 
   lapply(
-    list("disease" = summands_d, "mortality" = summands_m),
+    list("primary" = summands_d, "secondary" = summands_m),
     function(smnd) apply(smnd, 2, function(smnd_..r)
       as.vector(tapply(smnd_..r, PERIOD, mean)))
   )

--- a/R/disease_calc.R
+++ b/R/disease_calc.R
@@ -146,16 +146,16 @@ dpaf_grad_delta_Sp <- function(grad_S_l, Sp, ID, PERIOD) {
 #' @return named vector of mortalities \eqn{I} (see Warning on names)
 #' @keywords internal
 dpaf_grad_I <- function(grad_lambda_l, grad_dSp_l, lambda_l, dSp, PERIOD) {
-  summands_d <- grad_lambda_l[["primary"]] *
+  summands_1 <- grad_lambda_l[["primary"]] *
     lambda_l[["secondary"]] / do.call(`+`, lambda_l)^2 * dSp +
     grad_dSp_l[["primary"]] * lambda_l[["primary"]] / do.call(`+`, lambda_l)
 
-  summands_m <- -grad_lambda_l[["secondary"]] *
+  summands_2 <- -grad_lambda_l[["secondary"]] *
     lambda_l[["primary"]] / do.call(`+`, lambda_l)^2 * dSp +
     grad_dSp_l[["secondary"]] * lambda_l[["primary"]] / do.call(`+`, lambda_l)
 
   lapply(
-    list("primary" = summands_d, "secondary" = summands_m),
+    list("primary" = summands_1, "secondary" = summands_2),
     function(smnd) apply(smnd, 2, function(smnd_..r)
       as.vector(tapply(smnd_..r, PERIOD, mean)))
   )

--- a/R/disease_paf.R
+++ b/R/disease_paf.R
@@ -3,7 +3,7 @@
 #'
 #'
 #'
-#' If \code{covar_model} is not specified, the "hazard ratios" reported include
+#' If \code{hr_out} is not specified, the "hazard ratios" reported include
 #' all first order terms.
 #'
 #' \code{modifications} should be a named list of scalars or vectors. Each name
@@ -28,7 +28,7 @@
 #' @return a list of potentially interesting hazard ratio and PAF estimates
 #' @export
 dpaf_summary <- function(primary_resp, secondary_resp, predictors, dpaf_data,
-                         modifications, covar_model, prevalence_data,
+                         modifications, hr_out, prevalence_data,
                          group_vars, level = 0.95, ...) {
   # construct survival regression formulae
   primary_fm <- stats::update(primary_resp, predictors)
@@ -36,9 +36,9 @@ dpaf_summary <- function(primary_resp, secondary_resp, predictors, dpaf_data,
 
   # fit disease and mortality models using est_matrix -- see
   # est_matrix.R
-  fit1 <- est_matrix(primary_fm, dpaf_data, modifications, covar_model,
+  fit1 <- est_matrix(primary_fm, dpaf_data, modifications, hr_out,
                       level = level, ...)
-  fit2 <- est_matrix(secondary_fm, dpaf_data, modifications, covar_model,
+  fit2 <- est_matrix(secondary_fm, dpaf_data, modifications, hr_out,
                       level = level, ...)
 
   vv_l <- list("primary" = fit1$var, "secondary" = fit2$var)

--- a/R/disease_paf.R
+++ b/R/disease_paf.R
@@ -3,17 +3,17 @@
 #'
 #'
 #'
-#' If \code{covar_model} is not specified,
-#' the "hazard ratios" reported include all first order terms.
+#' If \code{covar_model} is not specified, the "hazard ratios" reported include
+#' all first order terms.
 #'
 #' \code{modifications} should be a named list of scalars or vectors. Each name
 #' should correspond to a column in \code{df}. The first element in each vector
 #' should be the desired output value. If there are subsequent elements in the
 #' vector, these identify which values to convert from.
-#' @param disease_resp formula with response for disease regression (note RHS
+#' @param primary_resp formula with response for primary outcome regression (note RHS
 #'   should be \code{.})
-#' @param death_resp formula with response for mortality regression (note RHS
-#'   should be \code{.})
+#' @param secondary_resp formula with response for secondary outcome regression
+#'   (note RHS should be \code{.})
 #' @param predictors formula with RHS containing predictors for both survival
 #'   regressions (LHS should be empty)
 #' @param dpaf_data an object of class \code{dpaf_response}, from
@@ -27,28 +27,28 @@
 #'
 #' @return a list of potentially interesting hazard ratio and PAF estimates
 #' @export
-dpaf_summary <- function(disease_resp, death_resp, predictors, dpaf_data,
+dpaf_summary <- function(primary_resp, secondary_resp, predictors, dpaf_data,
                          modifications, covar_model, prevalence_data,
                          group_vars, level = 0.95, ...) {
   # construct survival regression formulae
-  disease_fm <- stats::update(disease_resp, predictors)
-  mortality_fm <- stats::update(death_resp, predictors)
+  primary_fm <- stats::update(primary_resp, predictors)
+  secondary_fm <- stats::update(secondary_resp, predictors)
 
   # fit disease and mortality models using est_matrix -- see
   # est_matrix.R
-  fit_d <- est_matrix(disease_fm, dpaf_data, modifications, covar_model,
+  fit1 <- est_matrix(primary_fm, dpaf_data, modifications, covar_model,
                       level = level, ...)
-  fit_m <- est_matrix(mortality_fm, dpaf_data, modifications, covar_model,
+  fit2 <- est_matrix(secondary_fm, dpaf_data, modifications, covar_model,
                       level = level, ...)
 
-  vv_l <- list("disease" = fit_d$var, "mortality" = fit_m$var)
+  vv_l <- list("primary" = fit1$var, "secondary" = fit2$var)
 
   # calculate PAFs, possibly using new prevalence data -- see
   # disease_est.R
   if (missing(prevalence_data))
-    dpaf_all <- dpaf_est_paf(fit_d, fit_m, dpaf_data, level = level)
+    dpaf_all <- dpaf_est_paf(fit1, fit2, dpaf_data, level = level)
   else
-    dpaf_all <- dpaf_est_paf(fit_d, fit_m, dpaf_data, prevalence_data,
+    dpaf_all <- dpaf_est_paf(fit1, fit2, dpaf_data, prevalence_data,
                              level = level)
   # begin groupwise PAF estimates
   paf_groups <- NULL
@@ -62,7 +62,7 @@ dpaf_summary <- function(disease_resp, death_resp, predictors, dpaf_data,
 
     # call dpaf_est_paf for each subgroup -- again see disease_est.R
     paf_groups <- lapply(pd_spl, dpaf_est_paf,
-                         fit_d = fit_d, fit_m = fit_m,
+                         fit1 = fit1, fit2 = fit2,
                          paf_data = dpaf_data,
                          level = level)
     names(paf_groups) <- names(pd_spl)
@@ -76,13 +76,13 @@ dpaf_summary <- function(disease_resp, death_resp, predictors, dpaf_data,
       utils::combn(names(pd_spl), 2, paste, collapse = " - ")
   }
 
-  # prevent name collisions between fit_d and fit_m
-  names(fit_d) <- paste0(names(fit_d), "_d")
-  names(fit_m) <- paste0(names(fit_m), "_m")
+  # prevent name collisions between fit1 and fit2
+  names(fit1) <- paste0(names(fit1), "_primary")
+  names(fit2) <- paste0(names(fit2), "_secondary")
 
   retlist <- c(list(call = match.call()),
                list("nobs" = dpaf_data$nobs, "na.action" = dpaf_data$na.action),
-               fit_d, fit_m, dpaf_all,
+               fit1, fit2, dpaf_all,
                group_pafs = list(paf_groups),
                paf_diffs = list(paf_diffs))
   class(retlist) <- "dpaf_summary"

--- a/R/disease_paf.R
+++ b/R/disease_paf.R
@@ -77,8 +77,8 @@ dpaf_summary <- function(primary_resp, secondary_resp, predictors, dpaf_data,
   }
 
   # prevent name collisions between fit1 and fit2
-  names(fit1) <- paste0(names(fit1), "_primary")
-  names(fit2) <- paste0(names(fit2), "_secondary")
+  names(fit1) <- paste0(names(fit1), "_1")
+  names(fit2) <- paste0(names(fit2), "_2")
 
   retlist <- c(list(call = match.call()),
                list("nobs" = dpaf_data$nobs, "na.action" = dpaf_data$na.action),

--- a/R/est_matrix.R
+++ b/R/est_matrix.R
@@ -11,7 +11,7 @@
 #' there are subsequent elements in the vector, these identify which
 #' values to convert from.
 #'
-#' If \code{covar_model} is not specified,
+#' If \code{hr_out} is not specified,
 #' the "hazard ratios" reported include all first order terms.
 #'
 #' @section Warnings:
@@ -19,7 +19,7 @@
 #'   A hazard ratio is not well-defined when the term of interest is an
 #'   interaction. Use caution when interpreting such results.
 #'
-#'   When using interaction terms in \code{covar_model}, the wrong order of
+#'   When using interaction terms in \code{hr_out}, the wrong order of
 #'   covariate names will result in an error. Only terms that appear in
 #'   \code{attr(terms(sr_formula), "term.labels")} can be used.
 #'
@@ -27,7 +27,7 @@
 #' @param paf_response a response object as output by \code{\link{gen_data}}
 #' @param modifications a list of modifications to apply for PAF calculation;
 #'   see Details for more information
-#' @param covar_model an optional character vector describing variables of
+#' @param hr_out an optional character vector describing variables of
 #'   interest for hazard ratio calculation
 #' @param ... extra parameters to be passed to \code{survreg}
 #' @param level width of the confidence intervals for hazard ratios, default
@@ -56,7 +56,7 @@
 #'
 #' @export
 est_matrix <- function(sr_formula, paf_response, modifications,
-                       covar_model, level = 0.95, ...) {
+                       hr_out, level = 0.95, ...) {
   stopifnot(inherits(paf_response, c("mpaf_response", "dpaf_response")))
 
   # store call and modifications for user reference later if desired
@@ -82,12 +82,12 @@ est_matrix <- function(sr_formula, paf_response, modifications,
   matrix_data$terms <- Terms
 
   # handle missing covariate model -- get all first-order effects
-  if (missing(covar_model)) {
-    covar_model <- attr(Terms, "term.labels")[attr(Terms, "order") == 1]
+  if (missing(hr_out)) {
+    hr_out <- attr(Terms, "term.labels")[attr(Terms, "order") == 1]
   }
 
   # select which hazard ratios to calculate and report. This is a mess.
-  params <- unlist(lapply(covar_model, function(label) {
+  params <- unlist(lapply(hr_out, function(label) {
     # given a label (like "COVAR" or "factor1:factor2"), determine which factors
     # need to be included
     inc <- which(attr(Terms, "factors")[,label] > 0)

--- a/R/mortality_est.R
+++ b/R/mortality_est.R
@@ -8,9 +8,9 @@
 #'
 #' @export
 mpaf_est_matrix <- function(sr_formula, paf_data, modifications,
-                            covar_model, level = 0.95, ...) {
+                            hr_out, level = 0.95, ...) {
   .Deprecated("est_matrix")
-  est_matrix(sr_formula, paf_data, modifications, covar_model,
+  est_matrix(sr_formula, paf_data, modifications, hr_out,
              level = 0.95, ...)
 }
 

--- a/R/mortality_est.R
+++ b/R/mortality_est.R
@@ -2,22 +2,22 @@
 #'
 #' This function is deprecated, see \code{\link{est_matrix}} for current usage.
 #'
-#' @param mpaf_data an object of class \code{mpaf_response} from
+#' @param paf_data an object of class \code{mpaf_response} from
 #'   \code{\link{gen_data}}
 #' @inheritParams est_matrix
 #'
 #' @export
-mpaf_est_matrix <- function(sr_formula, mpaf_data, modifications,
+mpaf_est_matrix <- function(sr_formula, paf_data, modifications,
                             covar_model, level = 0.95, ...) {
   .Deprecated("est_matrix")
-  est_matrix(sr_formula, mpaf_data, modifications, covar_model,
+  est_matrix(sr_formula, paf_data, modifications, covar_model,
              level = 0.95, ...)
 }
 
 #' Estimate mortality PAFs
 #'
 #' @param mpaf_fit an object of class \code{paf_est_matrix}
-#' @param mpaf_data an object of class \code{paf_data}, used for the
+#' @param paf_data an object of class \code{paf_data}, used for the
 #'   \code{\link{est_matrix}} call
 #' @param newdata new prevalences, as an object of class \code{paf_data}
 #' @param level width of confidence interval, default 0.95
@@ -35,15 +35,15 @@ mpaf_est_matrix <- function(sr_formula, mpaf_data, modifications,
 #'   difference calculations}
 #'
 #' @export
-mpaf_est_paf <- function(mpaf_fit, mpaf_data, newdata, level = 0.95) {
+mpaf_est_paf <- function(mpaf_fit, paf_data, newdata, level = 0.95) {
   if (!missing(newdata)) {
     # equivalence assertions
     stopifnot(inherits(newdata, "paf_data"))
-    if (!identical(mpaf_data$data_call$ft_breaks, newdata$data_call$ft_breaks))
+    if (!identical(paf_data$data_call$ft_breaks, newdata$data_call$ft_breaks))
       stop("Original periods and new periods are incompatible")
-    if (!identical(mpaf_data$data_call$variables, newdata$data_call$variables))
+    if (!identical(paf_data$data_call$variables, newdata$data_call$variables))
       stop("Original variables and new variables are different")
-    if (!identical(mpaf_data$data_call$period_factor,
+    if (!identical(paf_data$data_call$period_factor,
                    newdata$data_call$period_factor))
       stop(paste("Name of period factor columns are not equal.",
                  "Ensure mpaf_gen_data is called with identical",
@@ -53,8 +53,8 @@ mpaf_est_paf <- function(mpaf_fit, mpaf_data, newdata, level = 0.95) {
     PERIOD <- newdata$PERIOD
   } else {
     # setting ID and PERIOD
-    ID <- mpaf_data$ID
-    PERIOD <- mpaf_data$PERIOD
+    ID <- paf_data$ID
+    PERIOD <- paf_data$PERIOD
   }
   if (is_period_unsorted(ID, PERIOD))
     stop("Periods must be in ascending order by ID for PAF calculations")
@@ -63,7 +63,7 @@ mpaf_est_paf <- function(mpaf_fit, mpaf_data, newdata, level = 0.95) {
   tm <- mpaf_fit$terms
   cf <- mpaf_fit$coefficients
   vv <- mpaf_fit$var
-  dt <- diff(mpaf_data$breaks)
+  dt <- diff(paf_data$breaks)
 
   # Point estimate calculations ---------------------------------------------
 
@@ -93,7 +93,7 @@ mpaf_est_paf <- function(mpaf_fit, mpaf_data, newdata, level = 0.95) {
   I_0_star <- mpaf_I(1-S_star, PERIOD)
   if (length(levels(PERIOD)) > 1)
     names(I_0) <- names(I_0_star) <- paste0(
-      "(", mpaf_data$breaks[1], ",", utils::tail(mpaf_data$breaks, -1), "]"
+      "(", paf_data$breaks[1], ",", utils::tail(paf_data$breaks, -1), "]"
     )
 
   # I_(t, t+dt]^(*)
@@ -131,7 +131,7 @@ mpaf_est_paf <- function(mpaf_fit, mpaf_data, newdata, level = 0.95) {
   }
 
   dimnames(grad_I_0)[[1]] <- dimnames(grad_I_0_star)[[1]] <- paste0(
-    "(", mpaf_data$breaks[1], ",", utils::tail(mpaf_data$breaks, -1), "]"
+    "(", paf_data$breaks[1], ",", utils::tail(paf_data$breaks, -1), "]"
   )
 
   grad_ipaf0 <- grad_I_0_star / I_0_star - grad_I_0 / I_0

--- a/R/mortality_paf.R
+++ b/R/mortality_paf.R
@@ -10,11 +10,11 @@
 #'
 #' @return a list of potenitally interesting hazard ratio and PAF estimates
 #' @export
-mpaf_summary <- function(sr_formula, paf_data, modifications, covar_model,
+mpaf_summary <- function(sr_formula, paf_data, modifications, hr_out,
                          prevalence_data, group_vars, level = 0.95, ...) {
   # fit model using est_matrix -- see est_matrix.R
   mpaf_fit <- est_matrix(sr_formula, paf_data, modifications,
-                         covar_model, level = level, ...)
+                         hr_out, level = level, ...)
 
   # calculate PAFs, possibly using new prevalence data -- see mortality_est.R
   if (missing(prevalence_data))

--- a/R/mortality_paf.R
+++ b/R/mortality_paf.R
@@ -2,32 +2,32 @@
 #' differences
 #'
 #' @inheritParams est_matrix
-#' @param mpaf_data an object containing the response as in \code{\link{gen_data}}
-#' @param prevalence_data matrix of prevalences as class \code{mpaf_data}
+#' @param paf_data an object containing the response as in \code{\link{gen_data}}
+#' @param prevalence_data matrix of prevalences as class \code{paf_data}
 #' @param group_vars names of columns to group by in PAF difference estimations
 #' @param level width of confidence intervals, default 0.95
 #' @param ... extra parameters to be passed to \code{\link{est_matrix}}
 #'
 #' @return a list of potenitally interesting hazard ratio and PAF estimates
 #' @export
-mpaf_summary <- function(sr_formula, mpaf_data, modifications, covar_model,
+mpaf_summary <- function(sr_formula, paf_data, modifications, covar_model,
                          prevalence_data, group_vars, level = 0.95, ...) {
   # fit model using est_matrix -- see est_matrix.R
-  mpaf_fit <- est_matrix(sr_formula, mpaf_data, modifications,
+  mpaf_fit <- est_matrix(sr_formula, paf_data, modifications,
                          covar_model, level = level, ...)
 
   # calculate PAFs, possibly using new prevalence data -- see mortality_est.R
   if (missing(prevalence_data))
-    mpaf_all <- mpaf_est_paf(mpaf_fit, mpaf_data, level = level)
+    mpaf_all <- mpaf_est_paf(mpaf_fit, paf_data, level = level)
   else
-    mpaf_all <- mpaf_est_paf(mpaf_fit, mpaf_data, prevalence_data,
+    mpaf_all <- mpaf_est_paf(mpaf_fit, paf_data, prevalence_data,
                              level = level)
 
   # begin groupwise PAF estimates
   mpaf_groups <- NULL
   mpaf_diffs <- NULL
   if (!missing(group_vars)) {
-    pafdat <- if (missing(prevalence_data)) mpaf_data else prevalence_data
+    pafdat <- if (missing(prevalence_data)) paf_data else prevalence_data
 
     # split PAF data -- see paf_utils.R
     # include drop = FALSE to keep useful names
@@ -48,7 +48,7 @@ mpaf_summary <- function(sr_formula, mpaf_data, modifications, covar_model,
   }
 
   retlist <- c(list(call = match.call()), mpaf_fit, mpaf_all,
-               list("nobs" = mpaf_data$nobs, "na.action" = mpaf_data$na.action),
+               list("nobs" = paf_data$nobs, "na.action" = paf_data$na.action),
                group_pafs = list(mpaf_groups),
                paf_diffs = list(mpaf_diffs))
   class(retlist) <- "mpaf_summary"

--- a/R/paf_utils.R
+++ b/R/paf_utils.R
@@ -107,7 +107,7 @@ design_frames <- function(df, terms, modifications, xlev) {
 #' @param fsep character separator between two factors
 #'
 #' @return A named list of objects with class \code{dpaf_data} or
-#'   \code{mpaf_data}, with names corresponding to the names of the list output
+#'   \code{paf_data}, with names corresponding to the names of the list output
 #'   by \code{split}. If a named list was given in \code{INDICES}, then these
 #'   names will be included.
 #' @export

--- a/R/print.R
+++ b/R/print.R
@@ -88,17 +88,17 @@ print.dpaf_summary <- function(x, ..., coef_regex = "",
   }
   cat(vsep)
 
-  if (!is.null(x$survreg_d) || !is.null(x$survreg_m)) {
+  if (!is.null(x$survreg_1) || !is.null(x$survreg_2)) {
     cat("\nSurvival regression summary:\n")
 
-    if (!is.null(x$survreg_d)) {
+    if (!is.null(x$survreg_1)) {
       cat("\n    Disease:\n")
-      print(summary(x$survreg_d), digits = digits, ...)
+      print(summary(x$survreg_1), digits = digits, ...)
     }
 
-    if (!is.null(x$survreg_m)) {
+    if (!is.null(x$survreg_2)) {
       cat("\n    Mortality:\n")
-      print(summary(x$survreg_m), digits = digits, ...)
+      print(summary(x$survreg_2), digits = digits, ...)
     }
     cat(vsep)
   }
@@ -112,32 +112,32 @@ print.dpaf_summary <- function(x, ..., coef_regex = "",
     cat(vsep)
   }
 
-  if (!is.null(x$HR_d) || !is.null(x$HR_m)) {
+  if (!is.null(x$HR_1) || !is.null(x$HR_2)) {
     cat("\nHazard ratios:\n")
 
-    if (!is.null(x$HR_d)) {
+    if (!is.null(x$HR_1)) {
       cat("\n    Disease:\n")
-      print(x$HR_d, digits = digits, na.print = '--', ...)
+      print(x$HR_1, digits = digits, na.print = '--', ...)
     }
 
-    if (!is.null(x$HR_m)) {
+    if (!is.null(x$HR_2)) {
       cat("\n    Mortality:\n")
-      print(x$HR_m, digits = digits, na.print = '--', ...)
+      print(x$HR_2, digits = digits, na.print = '--', ...)
     }
 
     cat(vsep)
   }
 
-  if (!is.null(x$modifications_m)) {
+  if (!is.null(x$modifications_2)) {
     cat("\nModifications:\n")
-    lapply(X = seq_along(x$modifications_m), FUN = function(i, lst) {
+    lapply(X = seq_along(x$modifications_2), FUN = function(i, lst) {
       if (length(lst[[i]]) > 1)
         cat(names(lst)[i], ": ",  paste(lst[[i]][-1], collapse = ", "),
             " -> ", lst[[i]][1], "\n", sep = "")
       else
         cat(names(lst)[i], ": ", ".",
             " -> ", lst[[i]][1], "\n", sep = "")
-    }, lst = x$modifications_m)
+    }, lst = x$modifications_2)
     cat(vsep)
   }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -49,7 +49,7 @@ smoke_summary <- mpaf_summary(
   survival::Surv(f_end, DEATH) ~ B_COHORT * f_period + SEX + SMOKE,
   paf_data = smoke_data, 
   modifications = list(SMOKE = c("Never", "<30/day", ">=30/day")),
-  covar_model = c("SEX", "SMOKE")
+  hr_out = c("SEX", "SMOKE")
 )
 
 knitr::kable(rbind(smoke_summary$paf, smoke_summary$paf0), digits = 4)
@@ -71,7 +71,7 @@ bmi_summary <- dpaf_summary(
   predictors = ~ B_COHORT * f_period + SEX + BMI_2,
   dpaf_data = bmi_data,
   modifications = list(BMI_2 = "<25.0"), 
-  covar_model = c("SEX", "BMI_2")
+  hr_out = c("SEX", "BMI_2")
 )
 
 knitr::kable(rbind(bmi_summary$paf, bmi_summary$paf0), digits = 4)

--- a/README.Rmd
+++ b/README.Rmd
@@ -42,7 +42,7 @@ smoke_data <- gen_data(
   indata = minifhs, 
   id_var = "ID",
   ft_breaks = c(0,5,10,15,17),
-  death_ind = "DEATH", death_time = "DEATH_FT",
+  primary_ind = "DEATH", primary_time = "DEATH_FT",
   variables = c("B_COHORT", "SEX", "SMOKE")
 )
 smoke_summary <- mpaf_summary(
@@ -60,14 +60,14 @@ The process to calculate a disease PAF is similar, though the function calls var
 bmi_data <- gen_data(
   indata = minifhs,
   id_var = "ID", ft_breaks = c(0,5,10,15,17), 
-  death_ind = "DEATH", death_time = "DEATH_FT",
-  disease_ind = "DIAB", disease_time = "DIAB_FT", 
+  primary_ind = "DIAB", primary_time = "DIAB_FT", 
+  secondary_ind = "DEATH", secondary_time = "DEATH_FT",
   variables = c("B_COHORT", "SEX", "BMI_2")
 )
 
 bmi_summary <- dpaf_summary(
-  disease_resp = survival::Surv(f_end, DIAB) ~ .,
-  death_resp = survival::Surv(f_end, DEATH) ~ .,
+  primary_resp = survival::Surv(f_end, DIAB) ~ .,
+  secondary_resp = survival::Surv(f_end, DEATH) ~ .,
   predictors = ~ B_COHORT * f_period + SEX + BMI_2,
   dpaf_data = bmi_data,
   modifications = list(BMI_2 = "<25.0"), 

--- a/README.Rmd
+++ b/README.Rmd
@@ -79,5 +79,9 @@ knitr::kable(rbind(bmi_summary$paf, bmi_summary$paf0), digits = 4)
 
 Note that in both these cases, the period and follow-up time variables have been automatically named as `f_period` and `f_end` respectively. These names can be chosen in the call to `gen_data`.
 
+## Acknowledgements
+
+This package was started during a joint summer research scholarship funded by the Australian Mathematical Sciences Institute and UNSW Sydney in the summer of 2018-19.
+
 ## References
 - Laaksonen, M.A., Virtala, E., Knekt, P., Oja, H. and Härkänen, T., 2011. SAS macros for calculation of population attributable fraction in a cohort study design. *J Stat Softw*, 43(7), pp.1-25.

--- a/README.Rmd
+++ b/README.Rmd
@@ -47,7 +47,7 @@ smoke_data <- gen_data(
 )
 smoke_summary <- mpaf_summary(
   survival::Surv(f_end, DEATH) ~ B_COHORT * f_period + SEX + SMOKE,
-  mpaf_data = smoke_data, 
+  paf_data = smoke_data, 
   modifications = list(SMOKE = c("Never", "<30/day", ">=30/day")),
   covar_model = c("SEX", "SMOKE")
 )

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ smoke_summary <- mpaf_summary(
   survival::Surv(f_end, DEATH) ~ B_COHORT * f_period + SEX + SMOKE,
   paf_data = smoke_data, 
   modifications = list(SMOKE = c("Never", "<30/day", ">=30/day")),
-  covar_model = c("SEX", "SMOKE")
+  hr_out = c("SEX", "SMOKE")
 )
 
 knitr::kable(rbind(smoke_summary$paf, smoke_summary$paf0), digits = 4)
@@ -84,7 +84,7 @@ bmi_summary <- dpaf_summary(
   predictors = ~ B_COHORT * f_period + SEX + BMI_2,
   dpaf_data = bmi_data,
   modifications = list(BMI_2 = "<25.0"), 
-  covar_model = c("SEX", "BMI_2")
+  hr_out = c("SEX", "BMI_2")
 )
 
 knitr::kable(rbind(bmi_summary$paf, bmi_summary$paf0), digits = 4)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ smoke_data <- gen_data(
 )
 smoke_summary <- mpaf_summary(
   survival::Surv(f_end, DEATH) ~ B_COHORT * f_period + SEX + SMOKE,
-  mpaf_data = smoke_data, 
+  paf_data = smoke_data, 
   modifications = list(SMOKE = c("Never", "<30/day", ">=30/day")),
   covar_model = c("SEX", "SMOKE")
 )

--- a/README.md
+++ b/README.md
@@ -1,31 +1,38 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
-rpaf
-====
 
-The goal of rpaf is to allow for simple calculation of population attributable fractions (PAFs) for either disease or mortality using data from cohort studies.
+# rpaf
 
-It is intended as an R equivalent to the SAS macros developed by [Laaksonen et al. (2011)](#references).
+The goal of rpaf is to allow for simple calculation of population
+attributable fractions (PAFs) for either disease or mortality using data
+from cohort studies.
 
-Installation
-------------
+It is intended as an R equivalent to the SAS macros developed by
+[Laaksonen et al. (2011)](#references).
 
-You **cannot** currently install the released version of rpaf from [CRAN](https://CRAN.R-project.org) with:
+## Installation
+
+You **cannot** currently install the released version of rpaf from
+[CRAN](https://CRAN.R-project.org) with:
 
 ``` r
 install.packages("rpaf")
 ```
 
-However, you can install the development version of rpaf from [GitHub](https://github.com/inpowell/rpaf) using:
+However, you can install the development version of rpaf from
+[GitHub](https://github.com/inpowell/rpaf) using:
 
 ``` r
 devtools::install_github("https://github.com/inpowell/rpaf")
 ```
 
-Example
--------
+## Example
 
-Basic calculation of PAFs can be achieved using the `mpaf_summary` and `dpaf_summary` functions for mortality and disease PAFs respectively. For instance, in the case of the former, we may wish to determine the PAFs for mortality if everone who currently smokes in the Mini-Finland Health Survey is modified to have never smoked:
+Basic calculation of PAFs can be achieved using the `mpaf_summary` and
+`dpaf_summary` functions for mortality and disease PAFs respectively.
+For instance, in the case of the former, we may wish to determine the
+PAFs for mortality if everone who currently smokes in the Mini-Finland
+Health Survey is modified to have never smoked:
 
 ``` r
 library(rpaf)
@@ -46,18 +53,21 @@ smoke_summary <- mpaf_summary(
 knitr::kable(rbind(smoke_summary$paf, smoke_summary$paf0), digits = 4)
 ```
 
-|          |     PAF|   2.5 %|  97.5 %|
-|----------|-------:|-------:|-------:|
-| (0,5\]   |  0.1486|  0.1134|  0.1825|
-| (5,10\]  |  0.1169|  0.0895|  0.1434|
-| (10,15\] |  0.0871|  0.0665|  0.1073|
-| (15,17\] |  0.0787|  0.0537|  0.1030|
-| (0,5\]   |  0.1486|  0.1134|  0.1825|
-| (0,10\]  |  0.1302|  0.1000|  0.1593|
-| (0,15\]  |  0.1117|  0.0862|  0.1365|
-| (0,17\]  |  0.1066|  0.0823|  0.1304|
+|          |    PAF |  2.5 % | 97.5 % |
+| -------- | -----: | -----: | -----: |
+| (0,5\]   | 0.1486 | 0.1134 | 0.1825 |
+| (5,10\]  | 0.1169 | 0.0895 | 0.1434 |
+| (10,15\] | 0.0871 | 0.0665 | 0.1073 |
+| (15,17\] | 0.0787 | 0.0537 | 0.1030 |
+| (0,5\]   | 0.1486 | 0.1134 | 0.1825 |
+| (0,10\]  | 0.1302 | 0.1000 | 0.1593 |
+| (0,15\]  | 0.1117 | 0.0862 | 0.1365 |
+| (0,17\]  | 0.1066 | 0.0823 | 0.1304 |
 
-The process to calculate a disease PAF is similar, though the function calls vary slightly. Here we want to see the PAF for diabetes incidence if everyone in the study who has a high BMI (that is, above 25.0 kg/m^2) is instead modified to have a normal or low BMI:
+The process to calculate a disease PAF is similar, though the function
+calls vary slightly. Here we want to see the PAF for diabetes incidence
+if everyone in the study who has a high BMI (that is, above 25.0 kg/m^2)
+is instead modified to have a normal or low BMI:
 
 ``` r
 bmi_data <- gen_data(
@@ -80,20 +90,29 @@ bmi_summary <- dpaf_summary(
 knitr::kable(rbind(bmi_summary$paf, bmi_summary$paf0), digits = 4)
 ```
 
-|          |     PAF|   2.5 %|  97.5 %|
-|----------|-------:|-------:|-------:|
-| (0,5\]   |  0.6811|  0.5490|  0.7745|
-| (5,10\]  |  0.6801|  0.5491|  0.7731|
-| (10,15\] |  0.6802|  0.5497|  0.7728|
-| (15,17\] |  0.6795|  0.5476|  0.7729|
-| (0,5\]   |  0.6811|  0.5490|  0.7745|
-| (0,10\]  |  0.6804|  0.5492|  0.7735|
-| (0,15\]  |  0.6803|  0.5495|  0.7732|
-| (0,17\]  |  0.6803|  0.5496|  0.7730|
+|          |    PAF |  2.5 % | 97.5 % |
+| -------- | -----: | -----: | -----: |
+| (0,5\]   | 0.6811 | 0.5490 | 0.7745 |
+| (5,10\]  | 0.6801 | 0.5491 | 0.7731 |
+| (10,15\] | 0.6802 | 0.5497 | 0.7728 |
+| (15,17\] | 0.6795 | 0.5476 | 0.7729 |
+| (0,5\]   | 0.6811 | 0.5490 | 0.7745 |
+| (0,10\]  | 0.6804 | 0.5492 | 0.7735 |
+| (0,15\]  | 0.6803 | 0.5495 | 0.7732 |
+| (0,17\]  | 0.6803 | 0.5496 | 0.7730 |
 
-Note that in both these cases, the period and follow-up time variables have been automatically named as `f_period` and `f_end` respectively. These names can be chosen in the call to `gen_data`.
+Note that in both these cases, the period and follow-up time variables
+have been automatically named as `f_period` and `f_end` respectively.
+These names can be chosen in the call to `gen_data`.
 
-References
-----------
+## Acknowledgements
 
--   Laaksonen, M.A., Virtala, E., Knekt, P., Oja, H. and Härkänen, T., 2011. SAS macros for calculation of population attributable fraction in a cohort study design. *J Stat Softw*, 43(7), pp.1-25.
+This package was started during a joint summer research scholarship
+funded by the Australian Mathematical Sciences Institute and UNSW Sydney
+in the summer of 2018-19.
+
+## References
+
+  - Laaksonen, M.A., Virtala, E., Knekt, P., Oja, H. and Härkänen, T.,
+    2011. SAS macros for calculation of population attributable fraction
+    in a cohort study design. *J Stat Softw*, 43(7), pp.1-25.

--- a/demo/example-disease-bp-bmi.R
+++ b/demo/example-disease-bp-bmi.R
@@ -12,7 +12,7 @@ summary_bpxbmi <- dpaf_summary(
   ~ 0 + B_COHORT * f_period + SEX + BP + BP:BMI_2,
   dpaf_data = dpaf_bpxbmi,
   modifications = list(BMI_2 = "<25.0"),
-  covar_model = c("SEX", "BP", "BP:BMI_2"),
+  hr_out = c("SEX", "BP", "BP:BMI_2"),
   group_vars = "BP"
 )
 

--- a/demo/example-disease-smoke.R
+++ b/demo/example-disease-smoke.R
@@ -14,31 +14,29 @@ smoke_data <- gen_data(
   indata = minifhs,
   id_var = "ID",
   ft_breaks = c(0,5,10,15,17),
-  death_ind = "DEATH",
-  death_time = "DEATH_FT",
-  disease_ind = "DIAB",
-  disease_time = "DIAB_FT",
+  primary_ind = "DIAB", primary_time = "DIAB_FT",
+  secondary_ind = "DEATH", secondary_time = "DEATH_FT",
   variables = c("B_COHORT", "SEX", "SMOKE"),
   period_factor = "F_PERIOD",
   time_var = "F_TIME"
 )
 
-smoke_fitd <- est_matrix(survival::Surv(F_TIME, DIAB) ~
+smoke_fit1 <- est_matrix(survival::Surv(F_TIME, DIAB) ~
                            B_COHORT * F_PERIOD + SEX + SMOKE,
                          smoke_data,
                          list(SMOKE = c("Never", "<30/day", ">=30/day")),
                          covar_model = c("SEX", "SMOKE"))
-smoke_fitm <- est_matrix(survival::Surv(F_TIME, DEATH) ~
+smoke_fit2 <- est_matrix(survival::Surv(F_TIME, DEATH) ~
                            B_COHORT * F_PERIOD + SEX + SMOKE,
                          smoke_data,
                          list(SMOKE = c("Never", "<30/day", ">=30/day")),
                          covar_model = c("SEX", "SMOKE"))
 
-smoke_paf <- dpaf_est_paf(smoke_fitd, smoke_fitm, smoke_data)
+smoke_paf <- dpaf_est_paf(smoke_fit1, smoke_fit2, smoke_data)
 
 smoke_summ <- dpaf_summary(
-  disease_resp = survival::Surv(F_TIME, DIAB) ~ .,
-  death_resp = survival::Surv(F_TIME, DEATH) ~ .,
+  primary_resp = survival::Surv(F_TIME, DIAB) ~ .,
+  secondary_resp = survival::Surv(F_TIME, DEATH) ~ .,
   predictors = ~ 0 + B_COHORT * F_PERIOD + SEX + SMOKE,
   dpaf_data = smoke_data,
   modifications = list(SMOKE = c("Never", "<30/day", ">=30/day")),

--- a/demo/example-disease-smoke.R
+++ b/demo/example-disease-smoke.R
@@ -25,12 +25,12 @@ smoke_fit1 <- est_matrix(survival::Surv(F_TIME, DIAB) ~
                            B_COHORT * F_PERIOD + SEX + SMOKE,
                          smoke_data,
                          list(SMOKE = c("Never", "<30/day", ">=30/day")),
-                         covar_model = c("SEX", "SMOKE"))
+                         hr_out = c("SEX", "SMOKE"))
 smoke_fit2 <- est_matrix(survival::Surv(F_TIME, DEATH) ~
                            B_COHORT * F_PERIOD + SEX + SMOKE,
                          smoke_data,
                          list(SMOKE = c("Never", "<30/day", ">=30/day")),
-                         covar_model = c("SEX", "SMOKE"))
+                         hr_out = c("SEX", "SMOKE"))
 
 smoke_paf <- dpaf_est_paf(smoke_fit1, smoke_fit2, smoke_data)
 
@@ -40,5 +40,5 @@ smoke_summ <- dpaf_summary(
   predictors = ~ 0 + B_COHORT * F_PERIOD + SEX + SMOKE,
   dpaf_data = smoke_data,
   modifications = list(SMOKE = c("Never", "<30/day", ">=30/day")),
-  covar_model = c("SEX", "SMOKE")
+  hr_out = c("SEX", "SMOKE")
 )

--- a/demo/example-mortality-bp-bmi.R
+++ b/demo/example-mortality-bp-bmi.R
@@ -2,7 +2,7 @@ bpxbmi_data <- gen_data(minifhs, "ID", c(0,5,10,15,17), "DEATH", "DEATH_FT",
                         variables = c("B_COHORT", "SEX", "BP", "BMI_2"))
 bpxbmi_summary <- mpaf_summary(
   survival::Surv(f_end, DEATH) ~ B_COHORT * f_period + SEX + BP + BP:BMI_2,
-  mpaf_data = mpaf_bpxbmi,
+  paf_data = mpaf_bpxbmi,
   modifications = list(BMI_2 = "<25.0"),
   covar_model = c("SEX", "BP", "BP:BMI_2"),
   group_vars = "BP"

--- a/demo/example-mortality-bp-bmi.R
+++ b/demo/example-mortality-bp-bmi.R
@@ -4,7 +4,7 @@ bpxbmi_summary <- mpaf_summary(
   survival::Surv(f_end, DEATH) ~ B_COHORT * f_period + SEX + BP + BP:BMI_2,
   paf_data = mpaf_bpxbmi,
   modifications = list(BMI_2 = "<25.0"),
-  covar_model = c("SEX", "BP", "BP:BMI_2"),
+  hr_out = c("SEX", "BP", "BP:BMI_2"),
   group_vars = "BP"
 )
 

--- a/demo/example-mortality-smoke.R
+++ b/demo/example-mortality-smoke.R
@@ -4,7 +4,7 @@ summary_smoke <- mpaf_summary(
   survival::Surv(f_end, DEATH) ~ B_COHORT * f_period + SEX + SMOKE,
   paf_data = mpaf_smoke,
   modifications = list("SMOKE" = c("Never", "<30/day", ">=30/day")),
-  covar_model = c("SEX", "SMOKE")
+  hr_out = c("SEX", "SMOKE")
 )
 
 summary_smoke

--- a/demo/example-mortality-smoke.R
+++ b/demo/example-mortality-smoke.R
@@ -2,7 +2,7 @@ mpaf_smoke <- gen_data(minifhs, "ID", c(0,5,10,15,17), "DEATH", "DEATH_FT",
                        variables = c("SEX", "SMOKE", "B_COHORT"))
 summary_smoke <- mpaf_summary(
   survival::Surv(f_end, DEATH) ~ B_COHORT * f_period + SEX + SMOKE,
-  mpaf_data = mpaf_smoke,
+  paf_data = mpaf_smoke,
   modifications = list("SMOKE" = c("Never", "<30/day", ">=30/day")),
   covar_model = c("SEX", "SMOKE")
 )

--- a/man/dpaf_est_paf.Rd
+++ b/man/dpaf_est_paf.Rd
@@ -4,12 +4,12 @@
 \alias{dpaf_est_paf}
 \title{Estimate disease PAFs}
 \usage{
-dpaf_est_paf(fit_d, fit_m, paf_data, newdata, level = 0.95)
+dpaf_est_paf(fit1, fit2, paf_data, newdata, level = 0.95)
 }
 \arguments{
-\item{fit_d}{the \code{est_matrix} object fitted to disease incidence}
+\item{fit1}{the \code{est_matrix} object fitted to primary outcome}
 
-\item{fit_m}{the \code{est_matrix} object fitted to mortality}
+\item{fit2}{the \code{est_matrix} object fitted to secondary outcome}
 
 \item{paf_data}{an object of class \code{paf_data}, used for the
 \code{\link{est_matrix}} call}

--- a/man/dpaf_summary.Rd
+++ b/man/dpaf_summary.Rd
@@ -6,8 +6,7 @@
 differences}
 \usage{
 dpaf_summary(primary_resp, secondary_resp, predictors, dpaf_data,
-  modifications, covar_model, prevalence_data, group_vars, level = 0.95,
-  ...)
+  modifications, hr_out, prevalence_data, group_vars, level = 0.95, ...)
 }
 \arguments{
 \item{primary_resp}{formula with response for primary outcome regression (note RHS
@@ -25,7 +24,7 @@ regressions (LHS should be empty)}
 \item{modifications}{a list of modifications to apply for PAF calculation;
 see Details for more information}
 
-\item{covar_model}{an optional character vector describing variables of
+\item{hr_out}{an optional character vector describing variables of
 interest for hazard ratio calculation}
 
 \item{prevalence_data}{optional matrix of external prevalences as class
@@ -45,7 +44,7 @@ Calculate mortality PAF estimates, confidence intervals and groupwise
 differences
 }
 \details{
-If \code{covar_model} is not specified, the "hazard ratios" reported include
+If \code{hr_out} is not specified, the "hazard ratios" reported include
 all first order terms.
 
 \code{modifications} should be a named list of scalars or vectors. Each name

--- a/man/dpaf_summary.Rd
+++ b/man/dpaf_summary.Rd
@@ -5,16 +5,16 @@
 \title{Calculate mortality PAF estimates, confidence intervals and groupwise
 differences}
 \usage{
-dpaf_summary(disease_resp, death_resp, predictors, dpaf_data,
+dpaf_summary(primary_resp, secondary_resp, predictors, dpaf_data,
   modifications, covar_model, prevalence_data, group_vars, level = 0.95,
   ...)
 }
 \arguments{
-\item{disease_resp}{formula with response for disease regression (note RHS
+\item{primary_resp}{formula with response for primary outcome regression (note RHS
 should be \code{.})}
 
-\item{death_resp}{formula with response for mortality regression (note RHS
-should be \code{.})}
+\item{secondary_resp}{formula with response for secondary outcome regression
+(note RHS should be \code{.})}
 
 \item{predictors}{formula with RHS containing predictors for both survival
 regressions (LHS should be empty)}
@@ -45,8 +45,8 @@ Calculate mortality PAF estimates, confidence intervals and groupwise
 differences
 }
 \details{
-If \code{covar_model} is not specified,
-the "hazard ratios" reported include all first order terms.
+If \code{covar_model} is not specified, the "hazard ratios" reported include
+all first order terms.
 
 \code{modifications} should be a named list of scalars or vectors. Each name
 should correspond to a column in \code{df}. The first element in each vector

--- a/man/est_matrix.Rd
+++ b/man/est_matrix.Rd
@@ -4,8 +4,8 @@
 \alias{est_matrix}
 \title{Calculate model frames, parameter estimates and hazard ratios}
 \usage{
-est_matrix(sr_formula, paf_response, modifications, covar_model,
-  level = 0.95, ...)
+est_matrix(sr_formula, paf_response, modifications, hr_out, level = 0.95,
+  ...)
 }
 \arguments{
 \item{sr_formula}{a formula to be passed to \code{\link[survival]{survreg}}}
@@ -15,7 +15,7 @@ est_matrix(sr_formula, paf_response, modifications, covar_model,
 \item{modifications}{a list of modifications to apply for PAF calculation;
 see Details for more information}
 
-\item{covar_model}{an optional character vector describing variables of
+\item{hr_out}{an optional character vector describing variables of
 interest for hazard ratio calculation}
 
 \item{level}{width of the confidence intervals for hazard ratios, default
@@ -58,7 +58,7 @@ first element in each vector should be the desired output value. If
 there are subsequent elements in the vector, these identify which
 values to convert from.
 
-If \code{covar_model} is not specified,
+If \code{hr_out} is not specified,
 the "hazard ratios" reported include all first order terms.
 }
 \section{Warnings}{
@@ -67,7 +67,7 @@ the "hazard ratios" reported include all first order terms.
   A hazard ratio is not well-defined when the term of interest is an
   interaction. Use caution when interpreting such results.
 
-  When using interaction terms in \code{covar_model}, the wrong order of
+  When using interaction terms in \code{hr_out}, the wrong order of
   covariate names will result in an error. Only terms that appear in
   \code{attr(terms(sr_formula), "term.labels")} can be used.
 }

--- a/man/gen_data.Rd
+++ b/man/gen_data.Rd
@@ -5,12 +5,12 @@
 \alias{mpaf_gen_data}
 \title{Generate mortality PAF data from cohort data.}
 \usage{
-gen_data(indata, id_var, ft_breaks, death_ind, death_time, disease_ind,
-  disease_time, variables = character(0),
+gen_data(indata, id_var, ft_breaks, primary_ind, primary_time,
+  secondary_ind, secondary_time, variables = character(0),
   na.action = getOption("na.action"), period_factor = "f_period",
   time_var = "f_end")
 
-mpaf_gen_data(indata, id_var, ft_breaks, death_ind, death_time,
+mpaf_gen_data(indata, id_var, ft_breaks, primary_ind, primary_time,
   variables = character(0), na.action = getOption("na.action"),
   period_factor = "f_period", time_var = "f_end")
 }
@@ -21,18 +21,18 @@ mpaf_gen_data(indata, id_var, ft_breaks, death_ind, death_time,
 
 \item{ft_breaks}{Numeric vector of breaks between time periods}
 
-\item{death_ind}{(Optional) Name of logical column indicating if death
-occurred before censoring (i.e. \code{TRUE} if an individual died before
-the end of follow-up)}
+\item{primary_ind}{(Optional) Name of logical column indicating if primary
+outcome of interest occurred before censoring (i.e. \code{TRUE} if an
+individual died before the end of follow-up)}
 
-\item{death_time}{(Optional) Name of numerical column with individual time
-until death or censoring}
+\item{primary_time}{(Optional) Name of numerical column with individual time
+until primary outcome or censoring}
 
-\item{disease_ind}{(Optional) Name of logical column indicating if disease
+\item{secondary_ind}{(Optional) Name of logical column indicating if secondary outcome
 occurred before censoring}
 
-\item{disease_time}{(Optional) Name of numerical column with individual time
-until disease or censoring}
+\item{secondary_time}{(Optional) Name of numerical column with individual time
+until secondary outcome or censoring}
 
 \item{variables}{Character vector of predictor columns to keep from
 \code{indata}}

--- a/man/mpaf_est_matrix.Rd
+++ b/man/mpaf_est_matrix.Rd
@@ -4,13 +4,13 @@
 \alias{mpaf_est_matrix}
 \title{Calculations for mortality PAFs (deprecated)}
 \usage{
-mpaf_est_matrix(sr_formula, mpaf_data, modifications, covar_model,
+mpaf_est_matrix(sr_formula, paf_data, modifications, covar_model,
   level = 0.95, ...)
 }
 \arguments{
 \item{sr_formula}{a formula to be passed to \code{\link[survival]{survreg}}}
 
-\item{mpaf_data}{an object of class \code{mpaf_response} from
+\item{paf_data}{an object of class \code{mpaf_response} from
 \code{\link{gen_data}}}
 
 \item{modifications}{a list of modifications to apply for PAF calculation;

--- a/man/mpaf_est_matrix.Rd
+++ b/man/mpaf_est_matrix.Rd
@@ -4,7 +4,7 @@
 \alias{mpaf_est_matrix}
 \title{Calculations for mortality PAFs (deprecated)}
 \usage{
-mpaf_est_matrix(sr_formula, paf_data, modifications, covar_model,
+mpaf_est_matrix(sr_formula, paf_data, modifications, hr_out,
   level = 0.95, ...)
 }
 \arguments{
@@ -16,7 +16,7 @@ mpaf_est_matrix(sr_formula, paf_data, modifications, covar_model,
 \item{modifications}{a list of modifications to apply for PAF calculation;
 see Details for more information}
 
-\item{covar_model}{an optional character vector describing variables of
+\item{hr_out}{an optional character vector describing variables of
 interest for hazard ratio calculation}
 
 \item{level}{width of the confidence intervals for hazard ratios, default

--- a/man/mpaf_est_paf.Rd
+++ b/man/mpaf_est_paf.Rd
@@ -4,12 +4,12 @@
 \alias{mpaf_est_paf}
 \title{Estimate mortality PAFs}
 \usage{
-mpaf_est_paf(mpaf_fit, mpaf_data, newdata, level = 0.95)
+mpaf_est_paf(mpaf_fit, paf_data, newdata, level = 0.95)
 }
 \arguments{
 \item{mpaf_fit}{an object of class \code{paf_est_matrix}}
 
-\item{mpaf_data}{an object of class \code{paf_data}, used for the
+\item{paf_data}{an object of class \code{paf_data}, used for the
 \code{\link{est_matrix}} call}
 
 \item{newdata}{new prevalences, as an object of class \code{paf_data}}

--- a/man/mpaf_summary.Rd
+++ b/man/mpaf_summary.Rd
@@ -5,8 +5,8 @@
 \title{Calculate mortality PAF estimates, confidence intervals and groupwise
 differences}
 \usage{
-mpaf_summary(sr_formula, paf_data, modifications, covar_model,
-  prevalence_data, group_vars, level = 0.95, ...)
+mpaf_summary(sr_formula, paf_data, modifications, hr_out, prevalence_data,
+  group_vars, level = 0.95, ...)
 }
 \arguments{
 \item{sr_formula}{a formula to be passed to \code{\link[survival]{survreg}}}
@@ -16,7 +16,7 @@ mpaf_summary(sr_formula, paf_data, modifications, covar_model,
 \item{modifications}{a list of modifications to apply for PAF calculation;
 see Details for more information}
 
-\item{covar_model}{an optional character vector describing variables of
+\item{hr_out}{an optional character vector describing variables of
 interest for hazard ratio calculation}
 
 \item{prevalence_data}{matrix of prevalences as class \code{paf_data}}

--- a/man/mpaf_summary.Rd
+++ b/man/mpaf_summary.Rd
@@ -5,13 +5,13 @@
 \title{Calculate mortality PAF estimates, confidence intervals and groupwise
 differences}
 \usage{
-mpaf_summary(sr_formula, mpaf_data, modifications, covar_model,
+mpaf_summary(sr_formula, paf_data, modifications, covar_model,
   prevalence_data, group_vars, level = 0.95, ...)
 }
 \arguments{
 \item{sr_formula}{a formula to be passed to \code{\link[survival]{survreg}}}
 
-\item{mpaf_data}{an object containing the response as in \code{\link{gen_data}}}
+\item{paf_data}{an object containing the response as in \code{\link{gen_data}}}
 
 \item{modifications}{a list of modifications to apply for PAF calculation;
 see Details for more information}
@@ -19,7 +19,7 @@ see Details for more information}
 \item{covar_model}{an optional character vector describing variables of
 interest for hazard ratio calculation}
 
-\item{prevalence_data}{matrix of prevalences as class \code{mpaf_data}}
+\item{prevalence_data}{matrix of prevalences as class \code{paf_data}}
 
 \item{group_vars}{names of columns to group by in PAF difference estimations}
 

--- a/man/paf_data_split.Rd
+++ b/man/paf_data_split.Rd
@@ -19,7 +19,7 @@ paf_data_split(object, INDICES, lsep = ": ", fsep = ", ")
 }
 \value{
 A named list of objects with class \code{dpaf_data} or
-  \code{mpaf_data}, with names corresponding to the names of the list output
+  \code{paf_data}, with names corresponding to the names of the list output
   by \code{split}. If a named list was given in \code{INDICES}, then these
   names will be included.
 }

--- a/tests/testthat/test_dpaf_fit.R
+++ b/tests/testthat/test_dpaf_fit.R
@@ -5,13 +5,13 @@ library(rpaf)
 
 test_that("Single-period", {
     x <- matrix(c(1,0,0, 0,1,1), ncol = 2)
-    cf_d <- c(g1 = -log(0.5), g2 = -log(3))
-    cf_m <- c(g1 = -log(2), g2 = -1)
+    cf_1 <- c(g1 = -log(0.5), g2 = -log(3))
+    cf_2 <- c(g1 = -log(2), g2 = -1)
 
     id <- gl(3,1)
     period <- gl(1,3, ordered = TRUE)
 
-    lambda <- rpaf:::dpaf_lambda(x, list("primary" = cf_d, "secondary" = cf_m))
+    lambda <- rpaf:::dpaf_lambda(x, list("primary" = cf_1, "secondary" = cf_2))
     S <- rpaf:::dpaf_S(lambda, id, period, dt = c(1))
     Sp <- rpaf:::dpaf_Sp(S)
     dSp <- rpaf:::dpaf_delta_Sp(Sp, id, period)
@@ -32,9 +32,9 @@ test_that("Single-period", {
 
 test_that("Single-person", {
     x <- matrix(c(1,0,0, 0,1,1), ncol = 2)
-    cf_d <- c(g1 = -log(0.5), g2 = -log(3))
-    cf_m <- c(g1 = -log(2), g2 = -log(5))
-    cf <- list("primary" = cf_d, "secondary" = cf_m)
+    cf_1 <- c(g1 = -log(0.5), g2 = -log(3))
+    cf_2 <- c(g1 = -log(2), g2 = -log(5))
+    cf <- list("primary" = cf_1, "secondary" = cf_2)
 
     id <- gl(1,3)
     period <- gl(3,1)
@@ -59,9 +59,9 @@ test_that("Single-person", {
 
 test_that("Uneven period", {
   x <- matrix(c(1,0,0, 0,1,1), ncol = 2)
-  cf_d <- c(g1 = -log(0.5), g2 = -log(3))
-  cf_m <- c(g1 = -log(2), g2 = -log(5))
-  cf <- list("primary" = cf_d, "secondary" = cf_m)
+  cf_1 <- c(g1 = -log(0.5), g2 = -log(3))
+  cf_2 <- c(g1 = -log(2), g2 = -log(5))
+  cf <- list("primary" = cf_1, "secondary" = cf_2)
 
   id <- gl(1,3)
   period <- gl(3,1)

--- a/tests/testthat/test_dpaf_fit.R
+++ b/tests/testthat/test_dpaf_fit.R
@@ -11,15 +11,15 @@ test_that("Single-period", {
     id <- gl(3,1)
     period <- gl(1,3, ordered = TRUE)
 
-    lambda <- rpaf:::dpaf_lambda(x, list("disease" = cf_d, "mortality" = cf_m))
+    lambda <- rpaf:::dpaf_lambda(x, list("primary" = cf_d, "secondary" = cf_m))
     S <- rpaf:::dpaf_S(lambda, id, period, dt = c(1))
     Sp <- rpaf:::dpaf_Sp(S)
     dSp <- rpaf:::dpaf_delta_Sp(Sp, id, period)
 
-    expect_equal(lambda, list(disease = c(0.5, 3, 3),
-                              mortality = c(2, exp(1), exp(1))))
-    expect_equal(S, list(disease = c(exp(-0.5), exp(-3), exp(-3)),
-                         mortality = c(exp(-2), exp(-exp(1)), exp(-exp(1)))))
+    expect_equal(lambda, list("primary" = c(0.5, 3, 3),
+                              "secondary" = c(2, exp(1), exp(1))))
+    expect_equal(S, list("primary" = c(exp(-0.5), exp(-3), exp(-3)),
+                         "secondary" = c(exp(-2), exp(-exp(1)), exp(-exp(1)))))
     expect_equal(Sp, c(exp(-2.5), exp(-3 - exp(1)), exp(-3 - exp(1))))
     expect_equal(dSp, 1 - Sp)
 
@@ -34,7 +34,7 @@ test_that("Single-person", {
     x <- matrix(c(1,0,0, 0,1,1), ncol = 2)
     cf_d <- c(g1 = -log(0.5), g2 = -log(3))
     cf_m <- c(g1 = -log(2), g2 = -log(5))
-    cf <- list(disease = cf_d, mortality = cf_m)
+    cf <- list("primary" = cf_d, "secondary" = cf_m)
 
     id <- gl(1,3)
     period <- gl(3,1)
@@ -44,10 +44,10 @@ test_that("Single-person", {
     Sp <- rpaf:::dpaf_Sp(S)
     dSp <- rpaf:::dpaf_delta_Sp(Sp, id, period)
 
-    expect_equal(lambda, list(disease = c(0.5, 3, 3),
-                              mortality = c(2, 5, 5)))
-    expect_equal(S, list(disease = c(exp(-0.5), exp(-3.5), exp(-6.5)),
-                         mortality = c(exp(-2), exp(-7), exp(-12))))
+    expect_equal(lambda, list("primary" = c(0.5, 3, 3),
+                              "secondary" = c(2, 5, 5)))
+    expect_equal(S, list("primary" = c(exp(-0.5), exp(-3.5), exp(-6.5)),
+                         "secondary" = c(exp(-2), exp(-7), exp(-12))))
     expect_equal(Sp, c(exp(-2.5), exp(-10.5), exp(-18.5)))
 
     expect_equal(
@@ -61,7 +61,7 @@ test_that("Uneven period", {
   x <- matrix(c(1,0,0, 0,1,1), ncol = 2)
   cf_d <- c(g1 = -log(0.5), g2 = -log(3))
   cf_m <- c(g1 = -log(2), g2 = -log(5))
-  cf <- list(disease = cf_d, mortality = cf_m)
+  cf <- list("primary" = cf_d, "secondary" = cf_m)
 
   id <- gl(1,3)
   period <- gl(3,1)
@@ -69,8 +69,8 @@ test_that("Uneven period", {
   lambda <- rpaf:::dpaf_lambda(x, cf)
   S <- rpaf:::dpaf_S(lambda, id, period, c(1,1,1/3))
 
-  expect_equal(lambda, list(disease = c(0.5, 3, 3),
-                            mortality = c(2, 5, 5)))
-  expect_equal(S, list(disease = c(exp(-0.5), exp(-3.5), exp(-3.5 - 3/3)),
-                       mortality = c(exp(-2), exp(-7), exp(-7 - 5/3))))
+  expect_equal(lambda, list("primary" = c(0.5, 3, 3),
+                            "secondary" = c(2, 5, 5)))
+  expect_equal(S, list("primary" = c(exp(-0.5), exp(-3.5), exp(-3.5 - 3/3)),
+                       "secondary" = c(exp(-2), exp(-7), exp(-7 - 5/3))))
 })

--- a/tests/testthat/test_dpaf_grad.R
+++ b/tests/testthat/test_dpaf_grad.R
@@ -21,35 +21,35 @@ test_that("hazard and survival gradients", {
   ID <- gl(4, 2)
   PERIOD <- gl(2, 1, 8)
   breaks = 0:2
-  hz_d <- c(1,2,1,2,4,5,4,5)
-  hz_m <- c(2,3,2,3,6,7,6,7)
-  lambda <- list("primary" = hz_d, "secondary" = hz_m)
+  hz_1 <- c(1,2,1,2,4,5,4,5)
+  hz_2 <- c(2,3,2,3,6,7,6,7)
+  lambda <- list("primary" = hz_1, "secondary" = hz_2)
 
-  sv_d <- exp(-hz_d)
-  sv_m <- exp(-hz_m)
-  S <- list("primary" = sv_d, "secondary" = sv_m)
+  sv_1 <- exp(-hz_1)
+  sv_2 <- exp(-hz_2)
+  S <- list("primary" = sv_1, "secondary" = sv_2)
 
-  # grad <- dpaf_grad(z, hz_d, hz_m, sv_d, sv_m, breaks, ID, PERIOD)
+  # grad <- dpaf_grad(z, hz_1, hz_2, sv_1, sv_2, breaks, ID, PERIOD)
 
   # expected values
-  e_glambda_d <- matrix(c(1,0,0, 0,2,0, 1,0,0, 0,2,0, 4,0,4, 0,5,5, 4,0,4, 0,5,5),
+  e_glambda_1 <- matrix(c(1,0,0, 0,2,0, 1,0,0, 0,2,0, 4,0,4, 0,5,5, 4,0,4, 0,5,5),
                         ncol = 3, byrow = TRUE)
-  e_glambda_m <- matrix(c(2,0,0, 0,3,0, 2,0,0, 0,3,0, 6,0,6, 0,7,7, 6,0,6, 0,7,7),
+  e_glambda_2 <- matrix(c(2,0,0, 0,3,0, 2,0,0, 0,3,0, 6,0,6, 0,7,7, 6,0,6, 0,7,7),
                    ncol = 3, byrow = TRUE)
-  ecs_ghz_d <- matrix(c(1,0,0, 1,2,0, 1,0,0, 1,2,0,
+  ecs_ghz_1 <- matrix(c(1,0,0, 1,2,0, 1,0,0, 1,2,0,
                         4,0,4, 4,5,9, 4,0,4, 4,5,9),
                       ncol = 3, byrow = TRUE)
-  ecs_ghz_m <- matrix(c(2,0,0, 2,3,0, 2,0,0, 2,3,0,
+  ecs_ghz_2 <- matrix(c(2,0,0, 2,3,0, 2,0,0, 2,3,0,
                         6,0,6, 6,7,13, 6,0,6, 6,7,13),
                       ncol = 3, byrow = TRUE)
-  e_gS_d <- -exp(-hz_d) * ecs_ghz_d
-  e_gS_m <- -exp(-hz_m) * ecs_ghz_m
+  e_gS_1 <- -exp(-hz_1) * ecs_ghz_1
+  e_gS_2 <- -exp(-hz_2) * ecs_ghz_2
 
   glambda <- rpaf:::dpaf_grad_lambda(z, lambda)
-  expect_equal(glambda, list("primary" = e_glambda_d, "secondary" = e_glambda_m))
+  expect_equal(glambda, list("primary" = e_glambda_1, "secondary" = e_glambda_2))
 
   gS <- rpaf:::dpaf_grad_S(glambda, S, ID, PERIOD, diff(breaks))
-  expect_equal(gS, list("primary" = e_gS_d, "secondary" = e_gS_m))
+  expect_equal(gS, list("primary" = e_gS_1, "secondary" = e_gS_2))
 })
 
 test_that("morbidity gradients", {
@@ -78,24 +78,24 @@ test_that("morbidity gradients", {
   # product of survivals
   Sp <- c(0.9405, 0.8075, 0.6300)
 
-  Sp_gS_d <- (Sp * S[["primary"]]) %o% (-lambda[["primary"]])
-  Sp_gS_d[upper.tri(Sp_gS_d)] <- 0
-  Sp_gS_m <- (Sp * S[["secondary"]]) %o% (-lambda[["secondary"]])
-  Sp_gS_m[upper.tri(Sp_gS_m)] <- 0
+  Sp_gS_1 <- (Sp * S[["primary"]]) %o% (-lambda[["primary"]])
+  Sp_gS_1[upper.tri(Sp_gS_1)] <- 0
+  Sp_gS_2 <- (Sp * S[["secondary"]]) %o% (-lambda[["secondary"]])
+  Sp_gS_2[upper.tri(Sp_gS_2)] <- 0
 
   dSp <- -diff(c(1, Sp))
-  dSp_gS_d <- apply(Sp_gS_d, 2, function(col) -diff(c(0, col)))
-  dSp_gS_m <- apply(Sp_gS_m, 2, function(col) -diff(c(0, col)))
-  grad_dSp <- list("primary" = dSp_gS_d, "secondary" = dSp_gS_m)
+  dSp_gS_1 <- apply(Sp_gS_1, 2, function(col) -diff(c(0, col)))
+  dSp_gS_2 <- apply(Sp_gS_2, 2, function(col) -diff(c(0, col)))
+  grad_dSp <- list("primary" = dSp_gS_1, "secondary" = dSp_gS_2)
 
   dis_prob <- lambda[["primary"]] / do.call(`+`, lambda)
 
-  gdis_prob_d <- lambda[["secondary"]] / do.call(`+`, lambda)**2 * glambda$primary
-  gdis_prob_m <- -lambda[["primary"]] / do.call(`+`, lambda)**2 * glambda$secondary
+  gdis_prob_1 <- lambda[["secondary"]] / do.call(`+`, lambda)**2 * glambda$primary
+  gdis_prob_2 <- -lambda[["primary"]] / do.call(`+`, lambda)**2 * glambda$secondary
 
   smnd <- list(
-    "primary" = gdis_prob_d * dSp + dis_prob * dSp_gS_d,
-    "secondary" = gdis_prob_m * dSp + dis_prob * dSp_gS_m
+    "primary" = gdis_prob_1 * dSp + dis_prob * dSp_gS_1,
+    "secondary" = gdis_prob_2 * dSp + dis_prob * dSp_gS_2
   )
   rpaf:::dpaf_grad_I(glambda, grad_dSp, lambda, dSp, period)
   expect_equal(rpaf:::dpaf_grad_I(glambda, grad_dSp, lambda, dSp, period),

--- a/tests/testthat/test_est_matrix.R
+++ b/tests/testthat/test_est_matrix.R
@@ -12,7 +12,7 @@ df <- data.frame(
 )
 
 paf_data <- gen_data(df, id_var = "id", ft_breaks = c(0,5),
-                     death_ind = "died", death_time = "time", variables = "tmt",
+                     primary_ind = "died", primary_time = "time", variables = "tmt",
                      time_var = "f_time"
                      )
 test_that("reference levels", {

--- a/tests/testthat/test_est_matrix.R
+++ b/tests/testthat/test_est_matrix.R
@@ -19,7 +19,7 @@ test_that("reference levels", {
   paf_fit <- est_matrix(
     survival::Surv(f_time, died) ~ 1 + tmt, paf_data,
     modifications = list(tmt = "Y"),
-    covar_model = c("tmt")
+    hr_out = c("tmt")
   )
   expect_equal(paf_fit$HR[,1], c("tmtN" = 1, "tmtY" = 0.5))
   expect_equal(is.na(paf_fit$HR[1,]), c(FALSE, TRUE, TRUE),

--- a/tests/testthat/test_gen_data.R
+++ b/tests/testthat/test_gen_data.R
@@ -13,7 +13,7 @@ df <- data.frame(
 
 test_that("unordered breaks are corrected with warning", {
   expect_warning(paf_data <- gen_data(df, "id", ft_breaks = c(0,2,6,4),
-                                      death_ind = "ind", death_time = "time",
+                                      primary_ind = "ind", primary_time = "time",
                                       variables = "tmt"),
                  "Time breaks are not in order; reordering them.")
   expect_equal(paf_data$breaks, c(0,2,4,6))

--- a/tests/testthat/test_mpaf_grad.R
+++ b/tests/testthat/test_mpaf_grad.R
@@ -20,7 +20,7 @@ test_that("hazard and survival gradients", {
 
   S <- exp(-lambda)
 
-  # grad <- dpaf_grad(z, hz_d, hz_m, sv_d, sv_m, breaks, ID, PERIOD)
+  # grad <- dpaf_grad(z, hz_1, hz_2, sv_1, sv_2, breaks, ID, PERIOD)
 
   # expected values
   e_glambda <- matrix(c(2,0,0, 0,3,0, 2,0,0, 0,3,0, 6,0,6, 0,7,7, 6,0,6, 0,7,7),

--- a/tests/testthat/test_print.R
+++ b/tests/testthat/test_print.R
@@ -13,7 +13,7 @@ smoke_mpaf <- mpaf_summary(
   survival::Surv(f_end, DEATH) ~ B_COHORT + SEX + SMOKE,
   smoke_data,
   modifications = list(SMOKE = c("Never", "<30/day", ">=30/day")),
-  covar_model = c("SEX", "SMOKE")
+  hr_out = c("SEX", "SMOKE")
 )
 
 bmi_data <- gen_data(df, id_var = "ID", ft_breaks = c(0,17),
@@ -27,7 +27,7 @@ bmi_dpaf <- dpaf_summary(
   ~ B_COHORT + SEX + BMI_2,
   bmi_data,
   modifications = list(BMI_2 = "<25.0"),
-  covar_model = c("SEX", "BMI_2")
+  hr_out = c("SEX", "BMI_2")
 )
 
 test_that("disease PAF summary prints output headings", {

--- a/tests/testthat/test_print.R
+++ b/tests/testthat/test_print.R
@@ -6,7 +6,7 @@ library(rpaf)
 
 df <- minifhs[c(1:20, 1096),]
 smoke_data <- gen_data(df, id_var = "ID", ft_breaks = c(0,17),
-                       death_ind = "DEATH", death_time = "DEATH_FT",
+                       primary_ind = "DEATH", primary_time = "DEATH_FT",
                        variables = c("B_COHORT", "SEX", "SMOKE"))
 
 smoke_mpaf <- mpaf_summary(
@@ -17,8 +17,8 @@ smoke_mpaf <- mpaf_summary(
 )
 
 bmi_data <- gen_data(df, id_var = "ID", ft_breaks = c(0,17),
-                     death_ind = "DEATH", death_time = "DEATH_FT",
-                     disease_ind = "DIAB", disease_time = "DIAB_FT",
+                     primary_ind = "DIAB", primary_time = "DIAB_FT",
+                     secondary_ind = "DEATH", secondary_time = "DEATH_FT",
                      variables = c("B_COHORT", "SEX", "BMI_2")
                     )
 bmi_dpaf <- dpaf_summary(

--- a/tests/testthat/test_single_period.R
+++ b/tests/testthat/test_single_period.R
@@ -13,18 +13,18 @@ gdata <- gen_data(
 ) # strictly it's not okay to use this for both disease and death
 
 test_that("single-period mortality dimensionality", {
-  summary_m <- mpaf_summary(
+  summary_2 <- mpaf_summary(
     survival::Surv(f_end, DEATH) ~ B_COHORT + SEX + BMI_2,
     mpaf_data = gdata, modifications = list(BMI_2 = "<25.0"),
     covar_model = c("SEX", "BMI_2")
   )
 
-  expect_equal(dimnames(summary_m$paf0),
+  expect_equal(dimnames(summary_2$paf0),
                list("(0,17]", c("PAF", "2.5 %", "97.5 %")))
 })
 
 test_that("single-period disease dimensionality", {
-  summary_d <- dpaf_summary(
+  summary_1 <- dpaf_summary(
     survival::Surv(f_end, DIAB) ~ .,
     survival::Surv(f_end, DEATH) ~ .,
     ~ B_COHORT + SEX + BMI_2,
@@ -32,6 +32,6 @@ test_that("single-period disease dimensionality", {
     covar_model = c("SEX", "BMI_2")
   )
 
-  expect_equal(dimnames(summary_d$paf0),
+  expect_equal(dimnames(summary_1$paf0),
                list("(0,17]", c("PAF", "2.5 %", "97.5 %")))
 })

--- a/tests/testthat/test_single_period.R
+++ b/tests/testthat/test_single_period.R
@@ -16,7 +16,7 @@ test_that("single-period mortality dimensionality", {
   summary_2 <- mpaf_summary(
     survival::Surv(f_end, DEATH) ~ B_COHORT + SEX + BMI_2,
     paf_data = gdata, modifications = list(BMI_2 = "<25.0"),
-    covar_model = c("SEX", "BMI_2")
+    hr_out = c("SEX", "BMI_2")
   )
 
   expect_equal(dimnames(summary_2$paf0),
@@ -29,7 +29,7 @@ test_that("single-period disease dimensionality", {
     survival::Surv(f_end, DEATH) ~ .,
     ~ B_COHORT + SEX + BMI_2,
     dpaf_data = gdata, modifications = list(BMI_2 = "<25.0"),
-    covar_model = c("SEX", "BMI_2")
+    hr_out = c("SEX", "BMI_2")
   )
 
   expect_equal(dimnames(summary_1$paf0),

--- a/tests/testthat/test_single_period.R
+++ b/tests/testthat/test_single_period.R
@@ -7,8 +7,8 @@ library(rpaf)
 gdata <- gen_data(
   indata = head(minifhs, 20), # contains deaths and one diabetes case
   id_var = "ID", ft_breaks = c(0,17),
-  death_ind = "DEATH", death_time = "DEATH_FT",
-  disease_ind = "DIAB", disease_time = "DIAB_FT",
+  primary_ind = "DIAB", primary_time = "DIAB_FT",
+  secondary_ind = "DEATH", secondary_time = "DEATH_FT",
   variables = c("B_COHORT", "SEX", "BMI_2")
 ) # strictly it's not okay to use this for both disease and death
 

--- a/tests/testthat/test_single_period.R
+++ b/tests/testthat/test_single_period.R
@@ -15,7 +15,7 @@ gdata <- gen_data(
 test_that("single-period mortality dimensionality", {
   summary_2 <- mpaf_summary(
     survival::Surv(f_end, DEATH) ~ B_COHORT + SEX + BMI_2,
-    mpaf_data = gdata, modifications = list(BMI_2 = "<25.0"),
+    paf_data = gdata, modifications = list(BMI_2 = "<25.0"),
     covar_model = c("SEX", "BMI_2")
   )
 

--- a/vignettes/disease-paf.Rmd
+++ b/vignettes/disease-paf.Rmd
@@ -113,7 +113,7 @@ This function takes our model fit by `est_matrix` and the original data and calc
 
 ```r
 bmi_paf <- dpaf_est_paf(fit1 = bmi_fit_1, fit2 = bmi_fit_2,
-                        mpaf_data = smoke_data)
+                        paf_data = smoke_data)
 ```
 
 Note that this function optionally takes a `newdata` argument, which is useful when we want to use a different prevalence matrix. This argument **is expanded upon in further detail in another vignette**^[Except not yet.]. One can also specify the confidence interval width again for the PAFs, though now it does not need to be the same as the hazard ratio level, as it would be in the case of using `dpaf_summary`.

--- a/vignettes/disease-paf.Rmd
+++ b/vignettes/disease-paf.Rmd
@@ -72,15 +72,15 @@ The remaining elements of each list item represent the values we initially want 
 however, as `BMI_2` has only two factor levels (that is, `<25.0` and `>=25.0`), in this case this has the exact same effect as the line above.
 
 ## Further information
-The `dpaf_summary` object contains more information than is reported in the standard print function. For example, it includes the standard errors of the reported PAFs (in transformed space, \(\log(1-\text{PAF})\)), and the design frames (both raw and modified). Specific output can be accessed as from any other list in R, as in the following line of code or the tables below.[^1] Note that, because `dpaf_summary` fits two survival regressions, objects appended with `_d` refer to the model for disease, while those with `_m` refer to the model for mortality.
+The `dpaf_summary` object contains more information than is reported in the standard print function. For example, it includes the standard errors of the reported PAFs (in transformed space, \(\log(1-\text{PAF})\)), and the design frames (both raw and modified). Specific output can be accessed as from any other list in R, as in the following line of code or the tables below.[^1] Note that, because `dpaf_summary` fits two survival regressions, objects appended with `_1` refer to the model for outcome of interest (the "primary" outcome), while those with `_2` refer to the model for competing outcome (the "secondary" outcome).
 
 ```{r}
 bmi_summ$se_ipaf0
 ```
 
 ```{r results = 'asis', echo = FALSE}
-knitr::kable(bmi_summ$design_d[c(6:7, 58:59, 155:156),], caption = "Sample rows from `bmi_summ$design_d`")
-knitr::kable(bmi_summ$modified_d[c(6:7, 58:59, 155:156),], caption = "Sample rows from `bmi_summ$modified_d`")
+knitr::kable(bmi_summ$design_1[c(6:7, 58:59, 155:156),], caption = "Sample rows from `bmi_summ$design_1`")
+knitr::kable(bmi_summ$modified_1[c(6:7, 58:59, 155:156),], caption = "Sample rows from `bmi_summ$modified_1`")
 ```
 
 # Details
@@ -112,7 +112,7 @@ One can also here specify the width of the confidence intervals for hazard ratio
 This function takes our model fit by `est_matrix` and the original data and calculates the PAF we so desire. So, to find the same disease PAFs as in our example above, we would call
 
 ```r
-bmi_paf <- dpaf_est_paf(fit1 = bmi_fit_d, fit2 = bmi_fit_m,
+bmi_paf <- dpaf_est_paf(fit1 = bmi_fit_1, fit2 = bmi_fit_2,
                         mpaf_data = smoke_data)
 ```
 

--- a/vignettes/disease-paf.Rmd
+++ b/vignettes/disease-paf.Rmd
@@ -41,7 +41,7 @@ bmi_summ <- dpaf_summary(
   predictors = ~ 0 + B_COHORT * F_PERIOD + SEX + BMI_2, 
   dpaf_data = bmi_data,
   modifications = list(BMI_2 = "<25.0"),
-  covar_model = c("SEX", "BMI_2")
+  hr_out = c("SEX", "BMI_2")
 )
 bmi_summ
 ```
@@ -96,13 +96,13 @@ bmi_fit1 <- est_matrix(
   survival::Surv(F_TIME, DIAB) ~ 0 + B_COHORT * F_PERIOD + SEX + BMI_2, 
   paf_response = bmi_data,
   modifications = list(BMI_2 = "<25.0"),
-  covar_model = c("SEX", "BMI_2")
+  hr_out = c("SEX", "BMI_2")
 )
 bmi_fit2 <- est_matrix(
   survival::Surv(F_TIME, DEATH) ~ 0 + B_COHORT * F_PERIOD + SEX + BMI_2, 
   paf_response = bmi_data,
   modifications = list(BMI_2 = "<25.0"),
-  covar_model = c("SEX", "BMI_2")
+  hr_out = c("SEX", "BMI_2")
 )
 ```
 One can also here specify the width of the confidence intervals for hazard ratio reporting, which is by default 95%.

--- a/vignettes/disease-paf.Rmd
+++ b/vignettes/disease-paf.Rmd
@@ -29,15 +29,15 @@ bmi_data <- gen_data(
   indata = minifhs,
   id_var = "ID",
   ft_breaks = c(0,5,10,15,17),
-  death_ind = "DEATH", death_time = "DEATH_FT",
-  disease_ind = "DIAB", disease_time = "DIAB_FT",
+  primary_ind = "DIAB", primary_time = "DIAB_FT",
+  secondary_ind = "DEATH", secondary_time = "DEATH_FT",
   variables = c("B_COHORT", "SEX", "BMI_2"),
   period_factor = "F_PERIOD",
   time_var = "F_TIME"
 )
 bmi_summ <- dpaf_summary(
-  disease_resp = survival::Surv(F_TIME, DIAB) ~ .,
-  death_resp = survival::Surv(F_TIME, DEATH) ~ .,
+  primary_resp = survival::Surv(F_TIME, DIAB) ~ .,
+  secondary_resp = survival::Surv(F_TIME, DEATH) ~ .,
   predictors = ~ 0 + B_COHORT * F_PERIOD + SEX + BMI_2, 
   dpaf_data = bmi_data,
   modifications = list(BMI_2 = "<25.0"),
@@ -92,13 +92,13 @@ The `dpaf_summary` function should make life easier for those who want a quick d
 The `est_matrix` function fits a survival regression using `survival::survreg` on the prepared data. It takes the model formula for this survival regression and the PAF data we have prepared from `gen_data`. It also takes a list of modifications as described above and our covariate model for reporting hazard ratios. So, instead of the summary function above, we could start with
 
 ```r
-bmi_fit_d <- est_matrix(
+bmi_fit1 <- est_matrix(
   survival::Surv(F_TIME, DIAB) ~ 0 + B_COHORT * F_PERIOD + SEX + BMI_2, 
   paf_response = bmi_data,
   modifications = list(BMI_2 = "<25.0"),
   covar_model = c("SEX", "BMI_2")
 )
-bmi_fit_m <- est_matrix(
+bmi_fit2 <- est_matrix(
   survival::Surv(F_TIME, DEATH) ~ 0 + B_COHORT * F_PERIOD + SEX + BMI_2, 
   paf_response = bmi_data,
   modifications = list(BMI_2 = "<25.0"),
@@ -112,7 +112,7 @@ One can also here specify the width of the confidence intervals for hazard ratio
 This function takes our model fit by `est_matrix` and the original data and calculates the PAF we so desire. So, to find the same disease PAFs as in our example above, we would call
 
 ```r
-bmi_paf <- dpaf_est_paf(fit_d = bmi_fit_d, fit_m = bmi_fit_m,
+bmi_paf <- dpaf_est_paf(fit1 = bmi_fit_d, fit2 = bmi_fit_m,
                         mpaf_data = smoke_data)
 ```
 

--- a/vignettes/mortality-paf.Rmd
+++ b/vignettes/mortality-paf.Rmd
@@ -37,7 +37,7 @@ smoke_data <- gen_data(
 )
 smoke_summ <- mpaf_summary(
   sr_formula = survival::Surv(F_TIME, DEATH) ~ 0 + B_COHORT * F_PERIOD + SEX + SMOKE, 
-  mpaf_data = smoke_data,
+  paf_data = smoke_data,
   modifications = list(SMOKE = c("Never", "<30/day", ">=30/day")),
   covar_model = c("SEX", "SMOKE")
 )
@@ -102,7 +102,7 @@ One can also here specify the width of the confidence intervals for hazard ratio
 This function takes our model fit by `est_matrix` and the original data and calculates the PAF we so desire. So, to find the same mortality PAFs as in our example above, we would call
 
 ```r
-smoke_paf <- mpaf_est_paf(mpaf_fit = smoke_fit, mpaf_data = smoke_data)
+smoke_paf <- mpaf_est_paf(mpaf_fit = smoke_fit, paf_data = smoke_data)
 ```
 
 Note that this function optionally takes a `newdata` argument, which is useful when we want to use a different prevalence matrix. This argument **is expanded upon in further detail in another vignette**^[Except not yet.]. One can also specify the confidence interval width again for the PAFs, though now it does not need to be the same as the hazard ratio level, as it would be in the case of using `mpaf_summary`.

--- a/vignettes/mortality-paf.Rmd
+++ b/vignettes/mortality-paf.Rmd
@@ -29,8 +29,8 @@ smoke_data <- gen_data(
   indata = minifhs,
   id_var = "ID",
   ft_breaks = c(0,5,10,15,17),
-  death_ind = "DEATH",
-  death_time = "DEATH_FT",
+  primary_ind = "DEATH",
+  primary_time = "DEATH_FT",
   variables = c("B_COHORT", "SEX", "SMOKE"),
   period_factor = "F_PERIOD",
   time_var = "F_TIME"

--- a/vignettes/mortality-paf.Rmd
+++ b/vignettes/mortality-paf.Rmd
@@ -39,7 +39,7 @@ smoke_summ <- mpaf_summary(
   sr_formula = survival::Surv(F_TIME, DEATH) ~ 0 + B_COHORT * F_PERIOD + SEX + SMOKE, 
   paf_data = smoke_data,
   modifications = list(SMOKE = c("Never", "<30/day", ">=30/day")),
-  covar_model = c("SEX", "SMOKE")
+  hr_out = c("SEX", "SMOKE")
 )
 smoke_summ
 ```
@@ -92,7 +92,7 @@ smoke_fit <- est_matrix(
   survival::Surv(F_TIME, DEATH) ~ 0 + B_COHORT * F_PERIOD + SEX + SMOKE, 
   paf_response = smoke_data,
   modifications = list(SMOKE = c("Never", "<30/day", ">=30/day")),
-  covar_model = c("SEX", "SMOKE")
+  hr_out = c("SEX", "SMOKE")
 )
 ```
 One can also here specify the width of the confidence intervals for hazard ratio reporting, which is by default 95%.


### PR DESCRIPTION
Namely, we wanted to

- change `covar_model` to `hr_out`
- change `disease_ind` and `disease_time` to `primary_ind` and `primary_time` (being the primary outcome of interest
- change `death_ind` and `death_time` to `secondary_ind` and `secondary_time` (e.g. if death is a competing risk) or `primary_ind` and `primary_time` (if death is the primary outcome of interest) -- this step involved some changes to internal behaviour of some functions
- some changes were also made to function internals to hopefully assist with further development